### PR TITLE
[fix] ホームページコンポーネントを分離し、動的インポートを導入

### DIFF
--- a/viewer/src/app/page.tsx
+++ b/viewer/src/app/page.tsx
@@ -1,78 +1,18 @@
 "use client";
 
-import { useWebSocket } from "@/components/providers/WebSocketProvider";
-import { Superchat } from "@/components/superchat/superchat";
-import { WebSocketConnectionStatus } from "@/components/superchat/ws-connection-status";
-import { HeaderWalletButton } from "@/components/wallet/header-wallet-button";
-import { ConnectionStatus } from "@/lib/types/websocket";
-import { useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import dynamic from "next/dynamic";
+import { Suspense } from "react";
 
-export default function Home() {
-	const search_params = useSearchParams();
-	const { state, actions } = useWebSocket();
+// Dynamically import the HomePage component with ssr: false
+const HomePage = dynamic(() => import("@/components/home-page"), {
+	ssr: false,
+	loading: () => <div>Loading page content...</div>, // Add a basic loading indicator
+});
 
-	useEffect(() => {
-		const ws_url_encoded = search_params.get("wsUrl");
-		const streamer_address = search_params.get("streamerAddress");
-
-		console.log("Search params:", {
-			ws_url_encoded,
-			streamer_address,
-		});
-
-		if (
-			ws_url_encoded &&
-			streamer_address &&
-			state.status === ConnectionStatus.DISCONNECTED
-		) {
-			try {
-				const ws_url = decodeURIComponent(ws_url_encoded);
-				console.log(`Attempting to connect to WebSocket: ${ws_url}`);
-				console.log(`Streamer Wallet Address: ${streamer_address}`);
-				console.log(`Connection status: ${state.status}`);
-				console.log("Current WebSocket state:", state);
-
-				let final_url = ws_url;
-				if (!ws_url.endsWith("/ws")) {
-					final_url = ws_url.endsWith("/") ? `${ws_url}ws` : `${ws_url}/ws`;
-					console.log(`URLにパスが含まれていないため、/wsを追加: ${final_url}`);
-				}
-
-				actions.connect(final_url);
-			} catch (error) {
-				console.error("Failed to decode WebSocket URL:", error);
-				console.error("Original encoded URL:", ws_url_encoded);
-			}
-		} else {
-			console.log("Not connecting because:", {
-				hasWsUrl: Boolean(ws_url_encoded),
-				hasStreamerAddress: Boolean(streamer_address),
-				connectionStatus: state.status,
-			});
-		}
-	}, [search_params, state, actions]);
-
+export default function Page() {
 	return (
-		<div className="grid grid-rows-[auto_1fr_auto] items-center min-h-screen p-8 gap-8 sm:p-10 font-[family-name:var(--font-geist-sans)]">
-			<header className="w-full max-w-4xl mx-auto">
-				<div className="flex items-center justify-between w-full">
-					<h1 className="text-2xl font-bold">SUIperCHAT</h1>
-					<HeaderWalletButton />
-				</div>
-			</header>
-
-			<main className="flex flex-col gap-8 w-full">
-				<Superchat />
-			</main>
-
-			<footer className="flex gap-[24px] flex-wrap items-center justify-center">
-				<div className="text-sm text-muted-foreground">
-					© 2023 SUIperCHAT. All rights reserved.
-				</div>
-			</footer>
-
-			<WebSocketConnectionStatus />
-		</div>
+		<Suspense fallback={<div>Loading...</div>}>
+			<HomePage />
+		</Suspense>
 	);
 }

--- a/viewer/src/components/home-page.tsx
+++ b/viewer/src/components/home-page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useWebSocket } from "@/components/providers/WebSocketProvider";
+import { Superchat } from "@/components/superchat/superchat";
+import { WebSocketConnectionStatus } from "@/components/superchat/ws-connection-status";
+import { HeaderWalletButton } from "@/components/wallet/header-wallet-button";
+import { ConnectionStatus } from "@/lib/types/websocket";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+export default function HomePage() {
+	const search_params = useSearchParams();
+	const { state, actions } = useWebSocket();
+
+	useEffect(() => {
+		const ws_url_encoded = search_params.get("wsUrl");
+		const streamer_address = search_params.get("streamerAddress");
+
+		console.log("Search params:", {
+			ws_url_encoded,
+			streamer_address,
+		});
+
+		if (
+			ws_url_encoded &&
+			streamer_address &&
+			state.status === ConnectionStatus.DISCONNECTED
+		) {
+			try {
+				const ws_url = decodeURIComponent(ws_url_encoded);
+				console.log(`Attempting to connect to WebSocket: ${ws_url}`);
+				console.log(`Streamer Wallet Address: ${streamer_address}`);
+				console.log(`Connection status: ${state.status}`);
+				console.log("Current WebSocket state:", state);
+
+				let final_url = ws_url;
+				if (!ws_url.endsWith("/ws")) {
+					final_url = ws_url.endsWith("/") ? `${ws_url}ws` : `${ws_url}/ws`;
+					console.log(`URLにパスが含まれていないため、/wsを追加: ${final_url}`);
+				}
+
+				actions.connect(final_url);
+			} catch (error) {
+				console.error("Failed to decode WebSocket URL:", error);
+				console.error("Original encoded URL:", ws_url_encoded);
+			}
+		} else {
+			console.log("Not connecting because:", {
+				hasWsUrl: Boolean(ws_url_encoded),
+				hasStreamerAddress: Boolean(streamer_address),
+				connectionStatus: state.status,
+			});
+		}
+	}, [search_params, state, actions]);
+
+	return (
+		<div className="grid grid-rows-[auto_1fr_auto] items-center min-h-screen p-8 gap-8 sm:p-10 font-[family-name:var(--font-geist-sans)]">
+			<header className="w-full max-w-4xl mx-auto">
+				<div className="flex items-center justify-between w-full">
+					<h1 className="text-2xl font-bold">SUIperCHAT</h1>
+					<HeaderWalletButton />
+				</div>
+			</header>
+
+			<main className="flex flex-col gap-8 w-full">
+				<Superchat />
+			</main>
+
+			<footer className="flex gap-[24px] flex-wrap items-center justify-center">
+				<div className="text-sm text-muted-foreground">
+					© 2023 SUIperCHAT. All rights reserved.
+				</div>
+			</footer>
+
+			<WebSocketConnectionStatus />
+		</div>
+	);
+}


### PR DESCRIPTION
# 概要
`viewer/src/app/page.tsx` に直接記述されていたホーム画面のコンポーネント定義を `viewer/src/components/home-page.tsx` として分離しました。これにより、ルートページでは `home-page.tsx` を動的にインポートし、ローディング中にはSuspenseによるフォールバックが表示されるように変更しました。

# 変更内容
- [viewer/src/app/page.tsx] (ホーム画面のコンポーネント定義を削除し、`home-page.tsx`の動的インポートとSuspenseを追加)
- [viewer/src/components/home-page.tsx] (旧`viewer/src/app/page.tsx`からホーム画面コンポーネント定義を移動し新規作成)

# その他
特になし。